### PR TITLE
chore(docs): Add Uptime link to Docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,6 +60,7 @@ aux_links:
   Community: https://community.mapswipe.org
   Website: https://mapswipe.org
   Manager Dashboard: https://managers.mapswipe.org
+  UptimeRobot: https://status.mapswipe.org
 aux_links_new_tab: true
 
 # UI: "Edit this page" footer link

--- a/examples/create-project/README.md
+++ b/examples/create-project/README.md
@@ -18,7 +18,7 @@ Utility script: [`run.py`](run.py)
 
 ## Real-world usage
 
-- https://github.com/hotosm/fAIr/blob/develop/backend/core/mapswipe_client.py
+- https://github.com/hotosm/fAIr/blob/develop/backend/shared/integrations/mapswipe.py
 
 ## Getting started
 


### PR DESCRIPTION
Update the link of mapswipe client url from Fair project.
- https://github.com/hotosm/fAIr/blob/develop/backend/shared/integrations/mapswipe.py